### PR TITLE
Feature: Add cors configuration

### DIFF
--- a/WHCFC_Backend/index.js
+++ b/WHCFC_Backend/index.js
@@ -3,7 +3,7 @@ import cors from "cors";
 import "dotenv/config";
 import emailRoute from "./routes/email.js";
 import eventRoute from "./routes/agenda.js";
-import dotenv from "dotenv";
+//import dotenv from "dotenv";
 
 // Load environment variables
 //const env = process.env.NODE_ENV === "development" ? ".env.dev" : ".env";
@@ -13,7 +13,7 @@ const app = express();
 const port = process.env.port || 8000;
 
 const corsConfig = {
-  origin: ["http://localhost:4200", "https://whcfc.ca", "https://www.whcfc.ca"],
+  origin: process.env.NODE_ENV === "development" ? "http://localhost:4200" : ["https://whcfc.ca", "https://www.whcfc.ca"],
   allowedHeaders: ["Content-Type"],
   methods: ["GET", "POST"],
   maxAge: 3600 // 1 hour

--- a/WHCFC_Backend/package-lock.json
+++ b/WHCFC_Backend/package-lock.json
@@ -11,10 +11,11 @@
       "dependencies": {
         "@dotenvx/dotenvx": "^1.14.1",
         "cors": "^2.8.5",
+        "cross-env": "^10.1.0",
         "deep-email-validator": "^0.1.21",
         "express": "^4.21.0",
         "mysql2": "^3.11.3",
-        "nodemailer": "^6.9.15"
+        "nodemailer": "^6.9.15",
         "xss": "^1.0.15"
       },
       "devDependencies": {
@@ -44,6 +45,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "1.0.0",
@@ -338,6 +345,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/WHCFC_Backend/package.json
+++ b/WHCFC_Backend/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "npx @dotenvx/dotenvx run  -- node index.js",
-    "dev": "npx @dotenvx/dotenvx run -f .env.dev -- nodemon index.js",
+    "start": "cross-env NODE_ENV=production npx @dotenvx/dotenvx run  -- node index.js",
+    "dev": "cross-env NODE_ENV=development npx @dotenvx/dotenvx run -f .env.dev -- nodemon index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
@@ -13,6 +13,7 @@
   "dependencies": {
     "@dotenvx/dotenvx": "^1.14.1",
     "cors": "^2.8.5",
+    "cross-env": "^10.1.0",
     "deep-email-validator": "^0.1.21",
     "express": "^4.21.0",
     "mysql2": "^3.11.3",


### PR DESCRIPTION
This PR configures CORS and some added packages

Settings:
- origin: If the backend server is in "development" (using npm run dev), it only allows "http://localhost:4200" (the frontend server) to send requests to the backend server. Otherwise, it only allows "https://https://whcfc.ca" to send requests to the backend server
- allowedHeader: Only request headers with "Content-Type" are permitted (e.g. "application/json", "application/xml", "text/plain“)

Packages:
- nodemon: Automatically restarts a Node.js app when source files change so you don’t need to stop/start the server manually
- cross-env: Provide a consistent way to set env vars in package.json scripts (avoids Windows vs POSIX differences)