### PR TITLE
Fix: Remove invalid email reason

### DIFF
--- a/WHCFC_Backend/routes/email.js
+++ b/WHCFC_Backend/routes/email.js
@@ -71,7 +71,7 @@ router.route("/contact").post(async (req, res) => {
   if (!validatorResult.valid)
     return res.status(400).json({ message: validatorResult.msg });
 
-  const validationResult = await validate({
+  const emailValidationResult = await validate({
     email: email,
     validateRegex: true,
     validateMx: true,
@@ -80,10 +80,9 @@ router.route("/contact").post(async (req, res) => {
     validateSMTP: false
   });
 
-  if (!validationResult.valid)
+  if (!emailValidationResult.valid)
     return res.status(400).json({
-      message: "Email is not valid",
-      reason: validationResult.reason
+      message: "Email is not valid"
     });
 
   if (!phoneFormatValidator(phone) && !(phone === ""))


### PR DESCRIPTION
This PR removes the specific reasons for email validation failures. The change is intended to reduce the risk of exploitation by limiting the information exposed to users. Providing less information helps prevent potential attacks.

Unless the benefits of providing more detailed information to the user outweigh the security risks