### PR TITLE
fix: improve error handling for Resend API

### DIFF
--- a/WHCFC_Backend/routes/email.js
+++ b/WHCFC_Backend/routes/email.js
@@ -17,7 +17,7 @@ const emailSending = async (subject, body) => {
   });
 
   if (error)
-    throw new Error(error);
+    throw new Error(error.message);
 };
 
 const inputSanitizer = inputs => {


### PR DESCRIPTION
## Changes
- Fixed error handling in `emailSending` function
- Changed `throw new Error(error)` to `throw new Error(error.message)`

## Why
The Resend API returns an error object `{ name, message }`. 
Passing the object directly to `new Error()` would result in 
error message showing `[object Object]` instead of the actual error message.

## Related
Follow-up fix for PR #49