### PR TITLE
Temp: remove agenda

### DIFF
--- a/WHCFC_Backend/db/db-manager.js
+++ b/WHCFC_Backend/db/db-manager.js
@@ -1,5 +1,5 @@
 import mysql from "mysql2/promise";
-import { table_create_query } from "./table_query.js";
+import { contactTable } from "./table_query.js";
 
 class DBManager {
   static #pool = null;
@@ -118,7 +118,7 @@ class DBManager {
   static async #check() {
     try {
       // Create table if it doesn't exist
-      await DBManager.#pool.query(table_create_query);
+      await DBManager.#pool.query(contactTable);
       console.log("Table checked/created");
     }
     catch (error) {

--- a/WHCFC_Backend/db/table_query.js
+++ b/WHCFC_Backend/db/table_query.js
@@ -1,4 +1,4 @@
-const table_create_query = `
+const contactTable = `
   CREATE TABLE IF NOT EXISTS contact (
     id INT AUTO_INCREMENT PRIMARY KEY,
     firstname VARCHAR(255) NOT NULL,
@@ -7,7 +7,9 @@ const table_create_query = `
     phone VARCHAR(255),
     message TEXT NOT NULL
   );
+`;
 
+const agendaTable = `
   CREATE TABLE IF NOT EXISTS agenda (
     id INT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
@@ -19,5 +21,6 @@ const table_create_query = `
     team1 VARCHAR(255),
     team2 VARCHAR(255)
   );
-  `;
-export { table_create_query };
+`;
+
+export { contactTable, agendaTable };

--- a/WHCFC_Backend/index.js
+++ b/WHCFC_Backend/index.js
@@ -1,7 +1,7 @@
 import express from "express";
 import cors from "cors";
 import emailRoute from "./routes/email.js";
-import eventRoute from "./routes/agenda.js";
+//import eventRoute from "./routes/agenda.js";
 import dotenv from "dotenv";
 import DBManager from "./db/db-manager.js";
 
@@ -36,7 +36,7 @@ app.use(express.json({ limit: "1mb" }));
 app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 
 app.use("/send-email", emailRoute);
-app.use("/agenda", eventRoute);
+//app.use("/agenda", eventRoute);
 
 try {
   await DBManager.createPool(poolConfig);


### PR DESCRIPTION
This PR temporarily removes the API endpoint for agenda because it is currently not being used, as well as the endpoint has some security issues.

This PR also separates the create table queries into two different variables so that we could create the contact table without having to create the agenda table. It also allows for more dynamic choice of which queries to use. In the future, we could write some code such that it concatenates all the create table queries into one string and performs a multi-statement query.