### PR TITLE
Update the copyright year from 2025 to 2026

### DIFF
--- a/WHCFC_Frontend/src/app/components/footer/footer.component.ts
+++ b/WHCFC_Frontend/src/app/components/footer/footer.component.ts
@@ -51,7 +51,7 @@ export class FooterComponent {
   ];
 
   copyright =
-    '© 2025 White Haven Community Football Club. All rights reserved.';
+    '© 2026 White Haven Community Football Club. All rights reserved.';
 
   socials: SocialItem[] = [
     {


### PR DESCRIPTION
Update the copyright year from 2025 to 2026 in the
footer of the website.

Issue: https://github.com/White-Haven-Community-Club-Web-Dev/whcc_website/issues/75
Signed-off-by: Amarpreet Singh <amarpreet1997@gmail.com>