### PR TITLE
Remove the connect with us header item

### DIFF
--- a/WHCFC_Frontend/src/app/components/header/header.component.ts
+++ b/WHCFC_Frontend/src/app/components/header/header.component.ts
@@ -43,7 +43,7 @@ export class HeaderComponent {
   navItems: NavItem[] = [
     { label: 'WHO WE ARE', link: '/who-we-are' },
     { label: 'WHAT WE DO', link: '/what-we-do' },
-    { label: 'CONNECT WITH US', link: '/connect-with-us' },
+    // { label: 'CONNECT WITH US', link: '/connect-with-us' },
   ];
 
   cta: CtaConfig = {


### PR DESCRIPTION
Remove the Connect With Us header item for the time
being until the page gets enabled.

Issue: https://github.com/White-Haven-Community-Club-Web-Dev/whcc_website/issues/76.
Signed-off-by: Amarpreet Singh <amarpreet1997@gmail.com>